### PR TITLE
Fix/loss missing impropers

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ couplings = rna.compute_jcouplings(couplings=['H1H2', 'H2H3', 'H3H4'], residues=
 
 ### Prerequisite
 - [Modified version](https://github.com/kntkb/openff-toolkit/tree/v0.14.5) of openff-toolkit `0.11.5` is required to train espaloma using dgl datasets ([Zenodo](https://zenodo.org/records/8150601)), which were used to train `espaloma-0.3`.
-- OpenEye toolkit is required to load PBD files into OpenFF Molecule objects. Academic license can be obtained [here](https://www.eyesopen.com/academic-licensing).
+- OpenEye toolkit is required to load PDB files into OpenFF Molecule objects. Academic license can be obtained [here](https://www.eyesopen.com/academic-licensing).
 
 
 ### Copyright

--- a/espfit/app/train.py
+++ b/espfit/app/train.py
@@ -186,7 +186,7 @@ class EspalomaBase(object):
             return net
         
 
-    def save_model(self, net=None, best_model=None, model_name='espaloma.pt', output_directory_path=None):
+    def save_model(self, net=None, checkpoint_file=None, output_model='espaloma.pt', output_directory_path=None):
         """Save the Espaloma network model to a file.
         
         This method saves the Espaloma network model to a file in the specified output directory.
@@ -194,13 +194,14 @@ class EspalomaBase(object):
         Parameters
         ----------
         net : torch.nn.Sequential
-            The Espaloma network model to be saved.
+            The Espaloma network model to be saved. 
+            `net` attribute of the class will be used if available.
 
-        best_model : str
-            The path to the best model file.
+        checkpoint_file : str
+            The checkpoint exported during training that will be used to save the model.
 
-        model_name : str, default='espaloma.pt'
-            The name of the file to save the model to.
+        output_model : str, default='espaloma.pt'
+            The output file name for the model.
 
         output_directory_path : str, default=None
             The directory where the model should be saved. 
@@ -215,6 +216,9 @@ class EspalomaBase(object):
         else:
             output_directory_path = os.getcwd()
 
+        if self.net is not None:
+            net = self.net
+
         if net:
             modules = []
             for module in net:
@@ -227,9 +231,9 @@ class EspalomaBase(object):
             raise ValueError('No model provided.')
         
         # Save model
-        state_dict = torch.load(best_model, map_location=torch.device('cpu'))
+        state_dict = torch.load(checkpoint_file, map_location=torch.device('cpu'))
         net.load_state_dict(state_dict)
-        torch.save(net, os.path.join(output_directory_path, model_name))
+        torch.save(net, os.path.join(output_directory_path, output_model))
 
 
 class EspalomaModel(EspalomaBase):

--- a/espfit/utils/espaloma/module.py
+++ b/espfit/utils/espaloma/module.py
@@ -181,8 +181,14 @@ class GetLoss(torch.nn.Module):
             loss_charge = self.compute_charge_loss(g) * self.weights['charge']
         if self.weights['torsion'] > 0 and g.number_of_nodes('n4') > 0:
             loss_torsion = self.compute_torsion_loss(g) * self.weights['torsion']
+        else:
+            # if no torsion, set to zero
+            loss_torsion = torch.tensor(0.0)
         if self.weights['improper'] > 0 and g.number_of_nodes('n4_improper') > 0:
             loss_improper = self.compute_improper_loss(g) * self.weights['improper']
+        else:
+            # if no improper, set to zero
+            loss_improper = torch.tensor(0.0)
 
         _logger.debug(f"energy: {loss_energy:.5f}, force: {loss_force:.5f}, charge: {loss_charge:.5f}, torsion: {loss_torsion:.5f}, improper: {loss_improper:.5f}")
         loss = loss_energy + loss_force + loss_charge + loss_torsion + loss_improper


### PR DESCRIPTION
## Description
Espaloma training sometimes fails due to missing improper torsions in the dataset because the loss assumes all dataset (molecules) have improper torsions. This behavior was resolved by setting improper loss to zero if improper is not present.

This PR also fixes #4 as an enhancement.

## Todos
Notable points that this PR has either accomplished or will accomplish.

## Questions

## Status
- [x] Ready to go